### PR TITLE
Remove duplicate vim tag

### DIFF
--- a/doc/yamsong.txt
+++ b/doc/yamsong.txt
@@ -2,7 +2,7 @@
 
 VIM REFERENCE MANUAL    by josef.fortier@gmail.com
 
-Help on using yamsong                                                    *yamsong*
+Help on using yamsong
 
 1. Introduction     |yamsong-intro|
 2. Usage            |yamsong-usage|


### PR DESCRIPTION
Fixes

[neobundle] Error generating helptags:
[neobundle] Vim(helptags):E154: Duplicate tag "yamsong" in file vim/neobundles/.neobundle/doc/yamsong.txt